### PR TITLE
Scratch image + multistage builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM fedora
+FROM scratch
 
 MAINTAINER Avesh Agarwal <avagarwa@redhat.com>
 
 COPY _output/bin/descheduler /bin/descheduler
-CMD ["/bin/descheduler --help"]
+
+ENTRYPOINT ["/bin/descheduler"]
+CMD ["--help"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,3 @@
-FROM golang:1.9.2
-
-WORKDIR /go/src/github.com/kubernetes-incubator/descheduler
-COPY . .
-RUN make
-
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +15,7 @@ FROM scratch
 
 MAINTAINER Avesh Agarwal <avagarwa@redhat.com>
 
-COPY --from=0 /go/src/github.com/kubernetes-incubator/descheduler/_output/bin/descheduler /bin/descheduler
+COPY _output/bin/descheduler /bin/descheduler
 
 ENTRYPOINT ["/bin/descheduler"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ IMAGE:=descheduler:$(VERSION)
 all: build
 
 build:
-	go build ${LDFLAGS} -o _output/bin/descheduler github.com/kubernetes-incubator/descheduler/cmd/descheduler 
+	CGO_ENABLED=0 go build ${LDFLAGS} -o _output/bin/descheduler github.com/kubernetes-incubator/descheduler/cmd/descheduler
 
 image: build
 	docker build -t $(IMAGE) .

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ build:
 	CGO_ENABLED=0 go build ${LDFLAGS} -o _output/bin/descheduler github.com/kubernetes-incubator/descheduler/cmd/descheduler
 
 image: build
+	docker build -f Dockerfile.dev -t $(IMAGE) .
+
+docker:
 	docker build -t $(IMAGE) .
 
 clean:


### PR DESCRIPTION
By disabling CGO, we can use the `scratch` image instead of the `fedora`
image, allowing a lighter weight image.

By setting up a multistage docker build, we can create the container image
in a single command. This eliminates external setup and allows us to build
this automatically on registries.